### PR TITLE
Release 0.3.1

### DIFF
--- a/lib/ps2/socket.ex
+++ b/lib/ps2/socket.ex
@@ -109,8 +109,14 @@ defmodule PS2.Socket do
     {:ok, state}
   end
 
-  def handle_disconnect(%{reason: %WebSockex.RequestError{code: 403 = code, message: message}}, state) do
-    Logger.error("Disconnected from the Socket: \"#{message}\" (error code #{code}). Make sure you have provided a valid service ID!")
+  def handle_disconnect(
+        %{reason: %WebSockex.RequestError{code: 403 = code, message: message}},
+        state
+      ) do
+    Logger.error(
+      "Disconnected from the Socket: \"#{message}\" (error code #{code}). Make sure you have provided a valid service ID!"
+    )
+
     {:ok, state}
   end
 
@@ -131,6 +137,7 @@ defmodule PS2.Socket do
     Logger.info(
       "Disconnected from the Socket, attempting to reconnect (#{attempt}/#{@max_reconnects})."
     )
+
     Logger.debug(inspect(conn))
 
     {:reconnect, state}

--- a/lib/ps2/socket_client.ex
+++ b/lib/ps2/socket_client.ex
@@ -5,9 +5,9 @@ defmodule PS2.SocketClient do
   ## Implementation
   To handle incoming game events, you need to pass a module with a `handle_event/1` callback to `PS2.Socket` when you
   start it. This behaviour provides an outline for developing such a module (Example implementation below). Events will
-  be passed to your client module via the `handle_event/1` in a tuple with the form of `{event_name, payload}`. Note
+  be passed to your client module via the `handle_event/1` in a tuple with the form of `{event_name, payload}`. **Note**
   that you should have a catch-all `handle_event/1` callback in the case of unhandled events (see example), otherwise
-  the client will crash whenever it receives an unknown event.
+  the client will crash whenever it receives an unknown event (or you are using metadata with `handle_event/2`).
 
   Once you have a module like the one below, pass it under the `:clients` option to your `PS2.Socket` (see that module's
   documentation for details).
@@ -61,4 +61,7 @@ defmodule PS2.SocketClient do
   @type subscription_list :: [subscription] | []
 
   @callback handle_event(event) :: any
+  @callback handle_event(event, metadata :: any()) :: any()
+
+  @optional_callbacks [handle_event: 2]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PS2.MixProject do
   def project do
     [
       app: :planetside_api,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule PS2.MixProject do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger]
     ]
   end
 

--- a/test/ps2/api_test.exs
+++ b/test/ps2/api_test.exs
@@ -43,7 +43,7 @@ defmodule PS2.APITest do
         |> term("name.first_lower", "snowful")
         |> show("character_id")
 
-      assert PS2.API.query(q) ===
+      assert PS2.API.query(q, Application.fetch_env!(:planetside_api, :service_id)) ===
                {:ok,
                 %QueryResult{
                   data: [%{"character_id" => "5428713425545165425"}],
@@ -58,7 +58,7 @@ defmodule PS2.APITest do
         |> term("name.first_lower", "snowful")
         |> show("character_id")
 
-      assert PS2.API.query_one(q) ===
+      assert PS2.API.query_one(q, Application.fetch_env!(:planetside_api, :service_id)) ===
                {:ok,
                 %QueryResult{
                   data: %{"character_id" => "5428713425545165425"},
@@ -67,7 +67,7 @@ defmodule PS2.APITest do
     end
 
     test "can retrieve collection list" do
-      {:ok, res} = PS2.API.get_collections()
+      {:ok, res} = PS2.API.get_collections(Application.fetch_env!(:planetside_api, :service_id))
       assert res.returned === 111
       assert length(res.data) === 111
     end
@@ -75,7 +75,7 @@ defmodule PS2.APITest do
     test "query with bad collection returns a PS2.API.Error with message \"No data found.\"" do
       q = Query.new() |> collection("does_not_exist")
 
-      assert PS2.API.query(q) ==
+      assert PS2.API.query(q, Application.fetch_env!(:planetside_api, :service_id)) ==
                {:error,
                 %PS2.API.Error{
                   message: "No data found.",
@@ -96,7 +96,7 @@ defmodule PS2.APITest do
         |> term("name.first_lower", "snowful")
         |> exact_match_first("invalid_value")
 
-      assert PS2.API.query(q) ==
+      assert PS2.API.query(q, Application.fetch_env!(:planetside_api, :service_id)) ==
                {:error,
                 %PS2.API.Error{
                   message: @invalid_search_term_message,

--- a/test/ps2/socket_test.exs
+++ b/test/ps2/socket_test.exs
@@ -5,7 +5,7 @@ defmodule PS2.SocketTest do
   doctest PS2.SocketClient
 
   @default_subs [
-    events: [PS2.gain_experience],
+    events: [PS2.gain_experience()],
     worlds: ["all"],
     characters: ["all"]
   ]
@@ -15,7 +15,6 @@ defmodule PS2.SocketTest do
   end
 
   describe "PS2.Socket" do
-
     test "can start up with a service ID", %{service_id: sid} do
       assert {:ok, _pid} = PS2.Socket.start_link(service_id: sid)
     end
@@ -27,14 +26,26 @@ defmodule PS2.SocketTest do
 
     test "can distribute GainExperience events to a SocketClient", %{service_id: sid} do
       assert true = Process.register(self(), :test_one_client)
-      {:ok, _pid} = PS2.Socket.start_link(subscriptions: @default_subs, clients: [TestClient], service_id: sid)
+
+      {:ok, _pid} =
+        PS2.Socket.start_link(
+          subscriptions: @default_subs,
+          clients: [TestClient],
+          service_id: sid
+        )
 
       assert_receive {TestClient, "GainExperience"}, 5000
     end
 
     test "can distribute GainExperience events to many SocketClients", %{service_id: sid} do
       assert true = Process.register(self(), :test_two_clients)
-      {:ok, _pid} = PS2.Socket.start_link(subscriptions: @default_subs, clients: [OtherTestClient, AnotherTestClient], service_id: sid)
+
+      {:ok, _pid} =
+        PS2.Socket.start_link(
+          subscriptions: @default_subs,
+          clients: [OtherTestClient, AnotherTestClient],
+          service_id: sid
+        )
 
       assert_receive {OtherTestClient, "GainExperience"}, 5000
       assert_receive {AnotherTestClient, "GainExperience"}, 5000
@@ -47,7 +58,8 @@ defmodule TestClient do
   @behaviour PS2.SocketClient
 
   @impl PS2.SocketClient
-  def handle_event({"GainExperience", _payload}), do: send(:test_one_client, {TestClient, "GainExperience"})
+  def handle_event({"GainExperience", _payload}),
+    do: send(:test_one_client, {TestClient, "GainExperience"})
 
   @impl PS2.SocketClient
   def handle_event({_event, _payload}), do: nil
@@ -58,7 +70,8 @@ defmodule OtherTestClient do
   @behaviour PS2.SocketClient
 
   @impl PS2.SocketClient
-  def handle_event({"GainExperience", _payload}), do: send(:test_two_clients, {OtherTestClient, "GainExperience"})
+  def handle_event({"GainExperience", _payload}),
+    do: send(:test_two_clients, {OtherTestClient, "GainExperience"})
 
   @impl PS2.SocketClient
   def handle_event({_event, _payload}), do: nil
@@ -69,7 +82,8 @@ defmodule AnotherTestClient do
   @behaviour PS2.SocketClient
 
   @impl PS2.SocketClient
-  def handle_event({"GainExperience", _payload}), do: send(:test_two_clients, {AnotherTestClient, "GainExperience"})
+  def handle_event({"GainExperience", _payload}),
+    do: send(:test_two_clients, {AnotherTestClient, "GainExperience"})
 
   @impl PS2.SocketClient
   def handle_event({_event, _payload}), do: nil


### PR DESCRIPTION
Adds backwards-compatible ability to pass `name: :none` when starting `PS2.Socket`, since the name defaults to `__MODULE__`.

Users can also add an optional `:metadata` key when starting the socket, which will be included alongside every event via the new optional `handle_event/2` callback. An arity 1 callback will still be required, even if it is just a catch-all function head.